### PR TITLE
make it build using externally installed jsonrpc-c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .project
 deps/out/
 out/
+CMakeCache.txt
+CMakeFiles
+Makefile
+cmake_install.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,9 @@ FIND_LIBRARY(JSONRPCC_LIBRARY
   NAMES
     jsonrpcc
   PATHS
+    /usr/lib64
     /usr/lib
+    /usr/local/lib64)
     /usr/local/lib)
 
 if (JSONRPCC_LIBRARY AND JSONRPCC_INCLUDE_DIRECTORY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ FIND_LIBRARY(JSONRPCC_LIBRARY
   PATHS
     /usr/lib64
     /usr/lib
-    /usr/local/lib64)
+    /usr/local/lib64
     /usr/local/lib)
 
 if (JSONRPCC_LIBRARY AND JSONRPCC_INCLUDE_DIRECTORY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ option(BUILD_DEBUG "Build for debug" OFF)
 
 # set global cmake  variables
 set(ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(DEPS_DIR ${ROOT_DIR}/deps)
-set(DEPS_OUT_DIR ${DEPS_DIR}/out)
 if (${BUILD_DEBUG})
     set(CMAKE_BUILD_TYPE Debug)
     add_definitions(-DA_DEBUG)
@@ -17,8 +15,40 @@ else()
     set(CMAKE_C_FLAGS_RELEASE "-O3 -std=gnu99")
 endif()
 
-link_directories(${DEPS_OUT_DIR}/lib)
-include_directories(${DEPS_OUT_DIR}/include)
 
-add_subdirectory(${DEPS_DIR})
+FIND_PATH(JSONRPCC_INCLUDE_DIRECTORY
+  NAMES
+    jsonrpc-c.h
+  PATHS
+    /usr/include/jsonrpc-c
+    /usr/local/include/jsonrpc-c
+    /usr/include
+    /usr/local/include)
+
+FIND_LIBRARY(JSONRPCC_LIBRARY
+  NAMES
+    jsonrpcc
+  PATHS
+    /usr/lib
+    /usr/local/lib)
+
+if (JSONRPCC_LIBRARY AND JSONRPCC_INCLUDE_DIRECTORY)
+  MESSAGE(STATUS "Jsonrpc-c seems to be installed on this computer, will use the installed version.")
+
+  include_directories(${JSONRPCC_INCLUDE_DIRECTORY})
+
+  SET(USE_INTERNAL_JSONRPCC False)
+else()
+  MESSAGE(STATUS "Jsonrpc-c is not installed on this computer, will use git submodule.")
+
+  set(DEPS_DIR ${ROOT_DIR}/deps)
+  set(DEPS_OUT_DIR ${DEPS_DIR}/out)
+
+  link_directories(${DEPS_OUT_DIR}/lib)
+  include_directories(${DEPS_OUT_DIR}/include)
+  set(JSONRPCC_LIBRARY jsonrpcc)
+  add_subdirectory(${DEPS_DIR})
+  SET(USE_INTERNAL_JSONRPCC True)
+endif()
+
 add_subdirectory(src)

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,1 @@
+airtame-cli

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,14 +11,16 @@ add_executable(${AIRTAME_CLI_TNAME}
         )
 
 if(APPLE)
-    set(AIRTAME_CLI_LIBS jsonrpcc)
+    set(AIRTAME_CLI_LIBS ${JSONRPCC_LIBRARY})
 elseif(UNIX)
-    set(AIRTAME_CLI_LIBS jsonrpcc pthread uuid)
+    set(AIRTAME_CLI_LIBS ${JSONRPCC_LIBRARY} pthread uuid)
 endif()
 
 target_link_libraries(${AIRTAME_CLI_TNAME}
         ${AIRTAME_CLI_LIBS})
 
-add_dependencies(${AIRTAME_CLI_TNAME} jsonrpc-c)
+if (USE_INTERNAL_JSONRPCC)
+  add_dependencies(${AIRTAME_CLI_TNAME} jsonrpc-c)
+endif()
 
 install(TARGETS ${AIRTAME_CLI_TNAME} DESTINATION bin)

--- a/src/main.c
+++ b/src/main.c
@@ -67,6 +67,7 @@ Thread_t ssdp_thread;
 struct jrpc_server *notifications_listener = NULL;
 struct jrpc_client cmds_client;
 Thread_t notifications_thread;
+int notifications_thread_started = 0;
 char cmd_line[MAX_CMDLINE_LENGTH];
 Thread_t cmdline_thread;
 
@@ -347,6 +348,7 @@ void read_cmdline(void *data) {
     jrpc_register_procedure(notifications_listener, streaming_state, "streamingState", NULL );
     jrpc_register_procedure(notifications_listener, connection_state, "connectionState", NULL );
     threading_create_thread(&notifications_thread, notifications_thread_main, NULL);
+    notifications_thread_started = 1;
     cJSON *result = jrpc_client_call(&cmds_client, "registerListener", 2, "127.0.0.1", not_port);
     print_rpc_result("registerListener", result);
 
@@ -599,7 +601,10 @@ int main(int argc, char **argv) {
     while (*runner) asleep(100);
 
     threading_cleanup_thread(&ssdp_thread);
-    threading_cleanup_thread(&notifications_thread);
+    if (notifications_thread_started)
+    {
+        threading_cleanup_thread(&notifications_thread);
+    }
     printf("\n");
     return 0;
 }


### PR DESCRIPTION
This patch makes it possible to build airtame-cli against a jsonrpc-c library that is already installed on the computer. The updated CMake scripts look for include files and libraries in some common places on Unix systems. If it fails to find the needed files the git submodule will be used instead.